### PR TITLE
++Refactor customfunctions.py and main.py

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "python.analysis.typeCheckingMode": "basic",
+    "python.analysis.autoImportCompletions": true,
+    "cursor.aipreview.enabled": true,
+    "editor.tabCompletion": "on",
+    "gitlens.ai.model": "anthropic:claude-3-5-sonnet-latest",
+    "github.copilot.chat.experimental.inlineChatCompletionTrigger.enabled": true,
+    "github.copilot.chat.experimental.startDebugging.enabled": true,
+    "github.copilot.chat.experimental.codeGeneration.instructions": [
+        {
+            "file": ".copilot-instructions.md"
+        }
+    ],
+    "cursor.general.disableHttp2": true,
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/configServices.py
+++ b/configServices.py
@@ -1,0 +1,115 @@
+from customfunctions import run_commands
+from customfunctions import run_command
+from customfunctions import cprint
+from customfunctions import confirmation
+
+def config_sysctl() -> None:
+    """
+    Configs sysctl
+
+    :return: None
+    """
+    run_commands([
+        "sed -i '$a net.ipv6.conf.all.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv6.conf.default.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv6.conf.lo.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.rp_filter=1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.accept_source_route=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_max_syn_backlog = 2048' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_synack_retries = 2' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_syn_retries = 5' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_syncookies=1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.ip_foward=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.send_redirects=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.default.send_redirects=0' /etc/sysctl.conf"
+    ])
+
+    run_command("sysctl -p", capture_output=False)
+    cprint("Sysctl configured", color="green")
+
+    confirmation()
+
+def openssh_config() -> None:
+    """
+    Configs ssh
+    """
+    run_commands([
+        "sed -i 's/LoginGraceTime .*/LoginGraceTime 60/g' /etc/ssh/sshd_config",
+        "sed -i 's/PermitRootLogin .*/PermitRootLogin no/g' /etc/ssh/sshd_config",
+        "sed -i 's/Protocol .*/Protocol 2/g' /etc/ssh/sshd_config",
+        "sed -i 's/#PermitEmptyPasswords .*/PermitEmptyPasswords no/g' /etc/ssh/sshd_config",
+        "sed -i 's/PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
+        "sed -i 's/X11Forwarding .*/X11Forwarding no/g' /etc/ssh/sshd_config"
+    ])
+    run_command("systemctl restart openssh-server", capture_output=False)
+    cprint("Openssh configured", color="green")
+
+    confirmation()
+    
+def mysql_config() -> None:
+    """
+    Configs mysql
+    """
+    run_commands([
+        "sed -i 's/bind-address .*/bind-address = 127.0.0.1/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/skip-external-locking .*/skip-external-locking = 1/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/key_buffer_size .*/key_buffer_size = 32M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/max_allowed_packet .*/max_allowed_packet = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/thread_stack .*/thread_stack = 256K/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/thread_cache_size .*/thread_cache_size = 8/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/query_cache_limit .*/query_cache_limit = 1M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/tmp_table_size .*/tmp_table_size = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/max_heap_table_size .*/max_heap_table_size = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf"
+    ])
+    run_command("systemctl restart mysql", capture_output=False)
+    cprint("Mysql configured", color="green")
+
+    confirmation()
+
+def apache2_config() -> None:
+    """
+    Configs apache2
+    """
+    run_commands([
+        "sed -i 's/ServerTokens .*/ServerTokens Prod/g' /etc/apache2/conf-available/security.conf",
+        "sed -i 's/ServerSignature .*/ServerSignature Off/g' /etc/apache2/conf-available/security.conf"
+    ])
+    run_command("systemctl restart apache2", capture_output=False)
+    cprint("Apache2 configured", color="green")
+
+    confirmation()
+
+def samba_config() -> None:
+    """
+    Configs samba
+    """
+    return
+
+def vsftpd_config() -> None:
+    """
+    Configs vsftpd
+    """
+    return
+
+def x11vnc_config() -> None:
+    """
+    Configs x11vnc
+    """
+    return
+"""Todo:
+- create config functions for each service
+    - openssh-server
+        - done
+    - openssh-client
+        - done
+    - mysql
+        - done
+    - apache2
+        - done
+    - samba 
+        - func declared needs to be done
+    - vsftpd 
+        - func declared needs to be done
+    - x11vnc 
+        - func declared needs to be done
+"""

--- a/customfunctions.py
+++ b/customfunctions.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 
-from typing_extensions import override
 
 
 def _get_command(command: str) -> list[str]:
@@ -88,3 +87,18 @@ def _get_decoration(bold: bool=False, underline: bool=False) -> str:
     if underline:
         decoration += "4;"
     return decoration
+
+#Todo finish this function
+import urllib.request
+def get_readme_data() -> str:
+    fp = urllib.request.urlopen("") #README url here
+    mybytes = fp.read()
+
+    mystr = mybytes.decode("utf8")
+    fp.close()
+    return mystr
+
+#Todo finish this function
+def parse_readme_data(data: str) -> list[str]:
+    my_list = data.splitlines()
+    users = []

--- a/main.py
+++ b/main.py
@@ -15,11 +15,12 @@ def main():
 
     secure_root()  # Secures root
 
-    secure_shadow()  # Secures shadow
+    secure_etc_files()  # Secures etc files
 
     remove_hacking_tools()  # Removes hacking tools
 
     possible_critical_services()  # Removes or keeps possible critical services in ReadMe
+    
 
 
 def ufw() -> None:
@@ -135,13 +136,16 @@ def secure_root() -> None:
     confirmation()
 
 
-def secure_shadow() -> None:
+def secure_etc_files() -> None:
     """
     Securing /etc/shadow
-
+    
     :return: None
     """
-    run_commands(["sudo chmod 640 /etc/shadow", "ls -l /etc/shadow"])
+    run_commands(["sudo chmod 640 /etc/shadow", "ls -l /etc/shadow",
+                  "sudo chmod 644 /etc/passwd", "ls -l /etc/passwd",
+                  "sudo chmod 644 /etc/group", "ls -l /etc/group",
+                  "sudo chmod 644 /etc/gshadow", "ls -l /etc/gshadow"])
 
     confirmation()
 
@@ -168,7 +172,7 @@ def possible_critical_services() -> None:
     Removes unneeded services that aren't listed on the ReadMe
 
     Installs and updates services that are needed
-
+    Secures known services
     :return: None
     """
     services = ["openssh-server", "openssh-client", "samba", "apache2", "vsftpd", "snmp", "x11vnc"]
@@ -192,14 +196,155 @@ def possible_critical_services() -> None:
         cprint(f"Done installing and upgrading {exclusion[i]}", color="green")
 
     cprint("Critical Services Installed!", color="green")
-    cprint(f"\nMake sure to SECURE these services: {', '.join(exclusion)}", color="red", bold=True, underline=True)
+    cprint("SECURING known services...", color="yellow")
+    for i in range(len(exclusion)):
+        cprint(f"Securing {exclusion[i]}", color="blue")
+        if exclusion[i] == "openssh-server":
+            openssh_config()
+        elif exclusion[i] == "mysql":
+            mysql_config()
+        elif exclusion[i] == "apache2":
+            apache2_config()
+        elif exclusion[i] == "samba":
+            samba_config()
+        elif exclusion[i] == "vsftpd":
+            vsftpd_config()
+        elif exclusion[i] == "x11vnc":
+            x11vnc_config()
+        elif exclusion[i] != "openssh-server" or "mysql" or "apache2" or "samba" or "vsftpd" or "x11vnc":
+            cprint(f"{exclusion[i]} is not a known service make sure to secure it manually", color="red")
+    cprint("Known services secured!", color="green")
+    
+    confirmation()
+    
+def config_sysctl() -> None:
+    """
+    Configs sysctl
+
+    :return: None
+    """
+    run_commands([
+        "sed -i '$a net.ipv6.conf.all.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv6.conf.default.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv6.conf.lo.disable_ipv6 = 1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.rp_filter=1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.accept_source_route=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_max_syn_backlog = 2048' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_synack_retries = 2' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_syn_retries = 5' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.tcp_syncookies=1' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.ip_foward=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.all.send_redirects=0' /etc/sysctl.conf",
+        "sed -i '$a net.ipv4.conf.default.send_redirects=0' /etc/sysctl.conf"
+    ])
+
+    run_command("sysctl -p", capture_output=False)
+    cprint("Sysctl configured", color="green")
 
     confirmation()
 
+def openssh_config() -> None:
+    """
+    Configs ssh
+    """
+    run_commands([
+        "sed -i 's/LoginGraceTime .*/LoginGraceTime 60/g' /etc/ssh/sshd_config",
+        "sed -i 's/PermitRootLogin .*/PermitRootLogin no/g' /etc/ssh/sshd_config",
+        "sed -i 's/Protocol .*/Protocol 2/g' /etc/ssh/sshd_config",
+        "sed -i 's/#PermitEmptyPasswords .*/PermitEmptyPasswords no/g' /etc/ssh/sshd_config",
+        "sed -i 's/PasswordAuthentication .*/PasswordAuthentication yes/g' /etc/ssh/sshd_config",
+        "sed -i 's/X11Forwarding .*/X11Forwarding no/g' /etc/ssh/sshd_config"
+    ])
+    run_command("systemctl restart openssh-server", capture_output=False)
+    cprint("Openssh configured", color="green")
 
+    confirmation()
+    
+def mysql_config() -> None:
+    """
+    Configs mysql
+    """
+    run_commands([
+        "sed -i 's/bind-address .*/bind-address = 127.0.0.1/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/skip-external-locking .*/skip-external-locking = 1/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/key_buffer_size .*/key_buffer_size = 32M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/max_allowed_packet .*/max_allowed_packet = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/thread_stack .*/thread_stack = 256K/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/thread_cache_size .*/thread_cache_size = 8/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/query_cache_limit .*/query_cache_limit = 1M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/tmp_table_size .*/tmp_table_size = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf",
+        "sed -i 's/max_heap_table_size .*/max_heap_table_size = 16M/g' /etc/mysql/mysql.conf.d/mysqld.cnf"
+    ])
+    run_command("systemctl restart mysql", capture_output=False)
+    cprint("Mysql configured", color="green")
+
+    confirmation()
+
+def apache2_config() -> None:
+    """
+    Configs apache2
+    """
+    run_commands([
+        "sed -i 's/ServerTokens .*/ServerTokens Prod/g' /etc/apache2/conf-available/security.conf",
+        "sed -i 's/ServerSignature .*/ServerSignature Off/g' /etc/apache2/conf-available/security.conf"
+    ])
+    run_command("systemctl restart apache2", capture_output=False)
+    cprint("Apache2 configured", color="green")
+
+    confirmation()
+
+def samba_config() -> None:
+    """
+    Configs samba
+    """
+    return
+
+def vsftpd_config() -> None:
+    """
+    Configs vsftpd
+    """
+    return
+
+def x11vnc_config() -> None:
+    """
+    Configs x11vnc
+    """
+    return
+
+def password_policy_config() -> None:
+    """
+    Configs password policy
+    """
+    run_commands([ #/etc/login.defs
+        "sed -i 's/PASS_MAX_DAYS .*/PASS_MAX_DAYS 90/g' /etc/login.defs",
+        "sed -i 's/PASS_MIN_DAYS .*/PASS_MIN_DAYS 10/g' /etc/login.defs",
+        "sed -i 's/PASS_WARN_AGE .*/PASS_WARN_AGE 7/g' /etc/login.defs"
+    ])
+    run_commands([ #/etc/pam.d/common-password
+        "sed -i 's/minlen .*/minlen 14/g' /etc/pam.d/common-password",
+        "sed -i 's/dcredit .*/dcredit -1/g' /etc/pam.d/common-password",
+        "sed -i 's/ucredit .*/ucredit -1/g' /etc/pam.d/common-password",
+        "sed -i 's/lcredit .*/lcredit -1/g' /etc/pam.d/common-password",
+        "sed -i 's/ocredit .*/ocredit -1/g' /etc/pam.d/common-password"
+    ])
+    cprint("Password policy configured", color="green")
+    confirmation()
 
 if __name__ == "__main__":
     _username = getpass.getuser()
     _password = getpass.getpass()
 
     main()
+"""Todo: create config functions for each service
+- openssh-server done
+- openssh-client done
+- mysql done
+- apache2 done
+- samba 
+    - func declared needs to be done
+- vsftpd 
+    - func declared needs to be done
+- x11vnc 
+    - func declared needs to be done
+- maybe put configs for services in a different file?
+- password policy done (needs testing)"""


### PR DESCRIPTION
++

Refactor customfunctions.py by removing unused import and typing_extensions override. Add unfinished functions get_readme_data() and parse_readme_data() in customfunctions.py. Refactor main.py by renaming secure_shadow() to secure_etc_files(). Add secure_etc_files() function to secure /etc/shadow, /etc/passwd, /etc/group, and /etc/gshadow. Add get_readme_data() function to retrieve data from a README file. Add parse_readme_data() function to parse the data from the README file. Update possible_critical_services() function in main.py to secure known services and print a message for unknown services. Add config_sysctl() function to configure sysctl. Add openssh_config(), mysql_config(), apache2_config(), samba_config(), vsftpd_config(), and x11vnc_config() functions to configure respective services. Add password_policy_config() function to test password policy.